### PR TITLE
Remove agora logo

### DIFF
--- a/src/consts/partners.json
+++ b/src/consts/partners.json
@@ -75,10 +75,6 @@
     {
       "alt": "discovery",
       "image": "/partners/discovery.png"
-    },
-    {
-      "alt": "agora sa",
-      "image": "/partners/agora-sa.png"
     }
   ],
   "PARTNERS": [


### PR DESCRIPTION
Remove agora logo from the lending page list of media partners