### PR TITLE
SOSUA-229 Add PIXEL by META

### DIFF
--- a/lib/fpixel.js
+++ b/lib/fpixel.js
@@ -1,0 +1,10 @@
+export const FB_PIXEL_ID = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID;
+
+export const pageview = () => {
+  window.fbq("track", "PageView");
+};
+
+// https://developers.facebook.com/docs/facebook-pixel/advanced/
+export const event = (name, options = {}) => {
+  window.fbq("track", name, options);
+};

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,11 @@
+/* eslint-disable jsx-a11y/alt-text */
+/* eslint-disable @next/next/no-img-element */
 import { Children } from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import { AppRegistry } from "react-native";
 import config from "../app.json";
+import { FB_PIXEL_ID } from "../lib/fpixel";
+
 // Force Next-generated DOM elements to fill their parent's height
 const normalizeNextElements = `
   #__next {
@@ -68,6 +72,14 @@ export default class MyDocument extends Document {
           />
           <meta name="msapplication-TileColor" content="#da532c" />
           <meta name="theme-color" content="#ffffff" />
+          <noscript>
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              src={`https://www.facebook.com/tr?id=${FB_PIXEL_ID}&ev=PageView&noscript=1`}
+            />
+          </noscript>
         </Head>
         <body style={{ height: "100%", overflow: "hidden" }}>
           <Main />


### PR DESCRIPTION
Add pixel by meta to the project according to the official next.js example.
To work properly need to add NEXT_PUBLIC_FACEBOOK_PIXEL_ID variable to .env.local

Example: https://github.com/vercel/next.js/tree/canary/examples/with-facebook-pixel